### PR TITLE
[#2] 전역 예외 처리, 커스텀 예외 공통 사항 적용

### DIFF
--- a/src/main/java/com/chang/omg/global/exception/BusinessException.java
+++ b/src/main/java/com/chang/omg/global/exception/BusinessException.java
@@ -1,0 +1,16 @@
+package com.chang.omg.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+    private final Object[] rejectedValues;
+
+    public BusinessException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+        this.rejectedValues = rejectedValues;
+    }
+}

--- a/src/main/java/com/chang/omg/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chang/omg/global/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.chang.omg.global.exception;
+
+public record ErrorResponse(String code) {
+
+}

--- a/src/main/java/com/chang/omg/global/exception/ExceptionCode.java
+++ b/src/main/java/com/chang/omg/global/exception/ExceptionCode.java
@@ -1,0 +1,12 @@
+package com.chang.omg.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+
+    HttpStatus getStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/chang/omg/global/exception/GlobalException.java
+++ b/src/main/java/com/chang/omg/global/exception/GlobalException.java
@@ -1,0 +1,8 @@
+package com.chang.omg.global.exception;
+
+public class GlobalException extends BusinessException {
+
+    public GlobalException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/com/chang/omg/global/exception/GlobalExceptionCode.java
+++ b/src/main/java/com/chang/omg/global/exception/GlobalExceptionCode.java
@@ -1,0 +1,20 @@
+package com.chang.omg.global.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalExceptionCode implements ExceptionCode {
+
+    GLOBAL_INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLO-001", "서버 내부 에러가 발생하였습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/chang/omg/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chang/omg/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.chang.omg.global.exception;
+
+import static com.chang.omg.global.exception.GlobalExceptionCode.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(final Exception exception) {
+        log.error("{}", GLOBAL_INTERNAL_SERVER_ERROR, exception);
+
+        return ResponseEntity.status(GLOBAL_INTERNAL_SERVER_ERROR.getStatus())
+                .body(new ErrorResponse(GLOBAL_INTERNAL_SERVER_ERROR.getCode()));
+    }
+}


### PR DESCRIPTION
## 📄 설명
- 모든 예외를 처리하기 위한 `@RestControllerAdvice`를 설정한다.
- 커스텀 예외를 이용하여 예외에 대한 코드를 정의한다.

## ✅ 할 일 목록
- [X] 전역 예외 처리 설정
- [X] 커스텀 예외 세팅
- [X] 커스텀 예외 에러 코드 정의

## 💬 기타
- 예외 발생시 문제되는 값을 **로그로 남기기 위해** Exception Class에 필드로 rejectedValues를 추가한다.