### PR TITLE
[#3] 개발 서버 ci/cd 환경 구축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,44 @@
+name: cd-dev
+
+on:
+  push:
+    branches: [ "dev" ]
+
+jobs:
+  deploy-to-ec2:
+    environment: dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Github Repository Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+
+      - name: Sending build file to NAS
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NAS_HOST }}
+          username: ${{ secrets.NAS_USERNAME }}
+          password: ${{ secrets.NAS_PASSWORD }}
+          source: "build/libs/*.jar"
+          target: "/root/omg/"
+
+      - name: SSH to NAS
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NAS_HOST }}
+          username: ${{ secrets.NAS_USERNAME }}
+          password: ${{ secrets.NAS_PASSWORD }}
+          script: |
+            cd /root/omg/
+            java -jar *.jar

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,24 @@
+name: ci-pr
+
+on:
+  pull_request:
+    branches: [ "main", "dev" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Github Repository Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+jar {
+    enabled = false
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }


### PR DESCRIPTION
## 📄 설명
- 개발 서버와 운영 서버를 분리한다.
- 개발 서버는 개인 NAS 서버를 이용한다.

## ✅ 할 일 목록
- [X] 개발 서버 NAS 구축
- [X] 개발 서버 CI, CD 설정

## 💬 기타
- NAS로 구현한 개발 서버의 경우 Docker를 이용하지 않고 SCP로 직접 전송하여 실행시키는 로직으로 구현해야 함
  - NAS의 Docker 기능으로 ubuntu를 구현하기 때문에 ubuntu안에서 또 Docker를 올릴 수 없음
- 운영 서버는 AWS 서버를 이용할 예정