### PR TITLE
[#12] github actions 배포 파일 수정(실행 스크립트 작성)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -42,5 +42,6 @@ jobs:
           username: ${{ secrets.NAS_USERNAME }}
           password: ${{ secrets.NAS_PASSWORD }}
           script: |
-            cd /root/omg/build/libs
-            nohub java -jar *.jar
+            cd /root/omg
+            ./process.sh
+            


### PR DESCRIPTION
## 📄 설명
- github actions 배포 파일 수정
- Docker를 사용하지 않아 프로세스를 직접 찾아 kill하고 다시 실행해야하는 문제 발생
- 관련 로직을 셸 스크립트로 작성하여 해당 스크립트를 실행할 수 있도록 변경

## ✅ 할 일 목록
- [X] cd-dev 파일 수정
- [X] 서버에 스크립트 작성
```shell
#!/bin/bash

# 'java' 프로세스의 PID를 찾습니다.
pid=$(ps -ef | grep 'java' | grep -v grep | awk '{print $2}')

# PID가 비어있지 않은 경우, 해당 프로세스를 종료합니다.
if [ -n "$pid" ]; then
  kill -9 $pid

  echo "Java process $pid has been terminated."
  echo "And start spring server."
else
  echo "No Java process found."
fi

nohup java -jar /root/omg/build/libs/*.jar &
```

## 💬 기타