### PR TITLE
[#16] API 요청 에러 응답 상세화

### DIFF
--- a/src/main/java/com/chang/omg/common/exception/ApiException.java
+++ b/src/main/java/com/chang/omg/common/exception/ApiException.java
@@ -1,0 +1,11 @@
+package com.chang.omg.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends BusinessException {
+
+    public ApiException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/com/chang/omg/common/exception/ApiExceptionCode.java
+++ b/src/main/java/com/chang/omg/common/exception/ApiExceptionCode.java
@@ -1,0 +1,22 @@
+package com.chang.omg.common.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiExceptionCode implements ExceptionCode {
+    API_INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "API-001", "게임사 서버에 에러가 발생하였습니다."),
+    API_BAD_REQUEST(BAD_REQUEST, "API-002", "요청 정보가 잘못되었습니다."),
+    API_FORBIDDEN(FORBIDDEN, "API-003", "요청 권한이 없습니다."),
+    API_TOO_MANY_REQUESTS(TOO_MANY_REQUESTS, "API_004", "요청이 너무 많습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/chang/omg/common/exception/ErrorResponse.java
+++ b/src/main/java/com/chang/omg/common/exception/ErrorResponse.java
@@ -1,5 +1,5 @@
 package com.chang.omg.common.exception;
 
-public record ErrorResponse(String code) {
+public record ErrorResponse(String code, String message) {
 
 }

--- a/src/main/java/com/chang/omg/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chang/omg/common/exception/GlobalExceptionHandler.java
@@ -12,11 +12,27 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(final ApiException apiException) {
+        log.error("외부 API 요청 에러: {}", apiException.getMessage(), apiException);
+
+        return ResponseEntity.status(apiException.getExceptionCode().getStatus())
+                .body(new ErrorResponse(
+                                apiException.getExceptionCode().getCode(),
+                                apiException.getExceptionCode().getMessage()
+                        )
+                );
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(final Exception exception) {
         log.error("{}", GLOBAL_INTERNAL_SERVER_ERROR, exception);
 
         return ResponseEntity.status(GLOBAL_INTERNAL_SERVER_ERROR.getStatus())
-                .body(new ErrorResponse(GLOBAL_INTERNAL_SERVER_ERROR.getCode()));
+                .body(new ErrorResponse(
+                                GLOBAL_INTERNAL_SERVER_ERROR.getCode(),
+                                GLOBAL_INTERNAL_SERVER_ERROR.getMessage()
+                        )
+                );
     }
 }

--- a/src/main/java/com/chang/omg/infrastructure/config/RestTemplateConfig.java
+++ b/src/main/java/com/chang/omg/infrastructure/config/RestTemplateConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
+import com.chang.omg.infrastructure.exception.RestTemplateResponseErrorHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
@@ -19,6 +20,7 @@ public class RestTemplateConfig {
     public RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
                 .messageConverters(getSnakeToCamelMessageConverter())
+                .errorHandler(new RestTemplateResponseErrorHandler())
                 .setConnectTimeout(Duration.ofSeconds(5))
                 .setReadTimeout(Duration.ofSeconds(5))
                 .build();

--- a/src/main/java/com/chang/omg/infrastructure/exception/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/chang/omg/infrastructure/exception/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,43 @@
+package com.chang.omg.infrastructure.exception;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import com.chang.omg.common.exception.ApiException;
+import com.chang.omg.common.exception.ApiExceptionCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+    @Override
+    public boolean hasError(final ClientHttpResponse response) throws IOException {
+        return response.getStatusCode().is5xxServerError() ||
+                response.getStatusCode().is4xxClientError();
+    }
+
+    @Override
+    public void handleError(final ClientHttpResponse response) throws IOException {
+        if (response.getStatusCode().is5xxServerError()) {
+            throw new ApiException(ApiExceptionCode.API_INTERNAL_SERVER_ERROR);
+        }
+
+        if (response.getStatusCode() == HttpStatus.BAD_REQUEST) {
+            throw new ApiException(ApiExceptionCode.API_BAD_REQUEST);
+        }
+
+        if (response.getStatusCode() == HttpStatus.FORBIDDEN) {
+            throw new ApiException(ApiExceptionCode.API_FORBIDDEN);
+        }
+
+        if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+            throw new ApiException(ApiExceptionCode.API_TOO_MANY_REQUESTS);
+        }
+    }
+}


### PR DESCRIPTION
## 📄 설명
- 외부 게임 서버 API로 요청하여 예외 발생시 모든 예외가 클라이언트에게 500 에러로 통일해서 나가는 문제를 해결한다.

## ✅ 할 일 목록
- [X] ResponseErrorHandler 구현
- [X] ApiException 및 Code 생성

## 💬 기타
참고 주소
https://medium.com/lucky-sonnie/spring-rest-api%EC%9D%98-request-response-%ED%95%B8%EB%93%A4%EB%A7%81-756596f2ae89
https://www.baeldung.com/spring-rest-template-error-handling