### PR TITLE
[#18] 게임 캐릭터 검색 기록 저장(MySQL)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -8,6 +8,15 @@ jobs:
   deploy-to-ec2:
     environment: dev
     runs-on: ubuntu-latest
+    env:
+      MAPLESTORYM_BASE_URL: ${{ secrets.MAPLESTORYM_BASE_URL }}
+      MAPLESTORYM_HEADER_KEY: ${{ secrets.MAPLESTORYM_HEADER_KEY }}
+      MAPLESTORYM_HEADER_VALUE: ${{ secrets.MAPLESTORYM_HEADER_VALUE }}
+      MAPLESTORYM_OCID_API_URI: ${{ secrets.MAPLESTORYM_OCID_API_URI }}
+      MAPLESTORYM_BASIC_API_URI: ${{ secrets.MAPLESTORYM_BASIC_API_URI }}
+      MAPLESTORYM_ITEM_API_URI: ${{ secrets.MAPLESTORYM_ITEM_API_URI }}
+      MAPLESTORYM_STAT_API_URI: ${{ secrets.MAPLESTORYM_STAT_API_URI }}
+      MAPLESTORYM_GUILD_API_URI: ${{ secrets.MAPLESTORYM_GUILD_API_URI }}
 
     steps:
       - name: Github Repository Checkout

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      MAPLESTORYM_BASE_URL: ${{ secrets.MAPLESTORYM_BASE_URL }}
+      MAPLESTORYM_HEADER_KEY: ${{ secrets.MAPLESTORYM_HEADER_KEY }}
+      MAPLESTORYM_HEADER_VALUE: ${{ secrets.MAPLESTORYM_HEADER_VALUE }}
+      MAPLESTORYM_OCID_API_URI: ${{ secrets.MAPLESTORYM_OCID_API_URI }}
+      MAPLESTORYM_BASIC_API_URI: ${{ secrets.MAPLESTORYM_BASIC_API_URI }}
+      MAPLESTORYM_ITEM_API_URI: ${{ secrets.MAPLESTORYM_ITEM_API_URI }}
+      MAPLESTORYM_STAT_API_URI: ${{ secrets.MAPLESTORYM_STAT_API_URI }}
+      MAPLESTORYM_GUILD_API_URI: ${{ secrets.MAPLESTORYM_GUILD_API_URI }}
 
     steps:
       - name: Github Repository Checkout

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/chang/omg/application/game/GameService.java
+++ b/src/main/java/com/chang/omg/application/game/GameService.java
@@ -1,13 +1,17 @@
 package com.chang.omg.application.game;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.chang.omg.domain.game.maplestorym.Character;
-import com.chang.omg.domain.game.maplestorym.CharacterBasic;
-import com.chang.omg.domain.game.maplestorym.CharacterGuild;
-import com.chang.omg.domain.game.maplestorym.CharacterItemEquipment;
-import com.chang.omg.domain.game.maplestorym.CharacterStat;
+import com.chang.omg.domain.game.maplestorym.domain.GameCharacterSearchLog;
+import com.chang.omg.domain.game.maplestorym.domain.GameType;
+import com.chang.omg.domain.game.maplestorym.repository.GameCharacterSearchLogRepository;
 import com.chang.omg.infrastructure.api.maplestorym.MapleStoryMApi;
+import com.chang.omg.infrastructure.api.maplestorym.dto.Character;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterBasic;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterGuild;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterItemEquipment;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterStat;
 import com.chang.omg.presentation.game.dto.MapleStoryMCharacterInfoResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -17,7 +21,9 @@ import lombok.RequiredArgsConstructor;
 public class GameService {
 
     private final MapleStoryMApi mapleStoryMApi;
+    private final GameCharacterSearchLogRepository gameCharacterSearchLogRepository;
 
+    @Transactional
     public MapleStoryMCharacterInfoResponse getMapleStoryMCharacterInfo(
             final String characterName,
             final String worldName
@@ -28,11 +34,23 @@ public class GameService {
         final CharacterStat characterStat = mapleStoryMApi.getCharacterStat(character.ocid());
         final CharacterGuild characterGuild = mapleStoryMApi.getCharacterGuild(character.ocid());
 
+        saveGameCharacterSearchLog(worldName, characterName);
+
         return MapleStoryMCharacterInfoResponse.of(
                 characterBasic,
                 characterItemEquipment,
                 characterStat,
                 characterGuild
         );
+    }
+
+    private void saveGameCharacterSearchLog(final String worldName, final String characterName) {
+        final GameCharacterSearchLog gameCharacterSearchLog = GameCharacterSearchLog.builder()
+                .gameType(GameType.MAPLESTORY_M)
+                .worldName(worldName)
+                .characterName(characterName)
+                .build();
+
+        gameCharacterSearchLogRepository.save(gameCharacterSearchLog);
     }
 }

--- a/src/main/java/com/chang/omg/common/exception/ApiExceptionCode.java
+++ b/src/main/java/com/chang/omg/common/exception/ApiExceptionCode.java
@@ -14,6 +14,7 @@ public enum ApiExceptionCode implements ExceptionCode {
     API_BAD_REQUEST(BAD_REQUEST, "API-002", "요청 정보가 잘못되었습니다."),
     API_FORBIDDEN(FORBIDDEN, "API-003", "요청 권한이 없습니다."),
     API_TOO_MANY_REQUESTS(TOO_MANY_REQUESTS, "API_004", "요청이 너무 많습니다."),
+    API_GAME_TYPE_IS_INVALID(BAD_REQUEST, "API_005", "게임 타입이 유효하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/chang/omg/domain/game/common/config/JpaConfig.java
+++ b/src/main/java/com/chang/omg/domain/game/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.chang.omg.domain.game.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/chang/omg/domain/game/common/domain/BaseEntity.java
+++ b/src/main/java/com/chang/omg/domain/game/common/domain/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.chang.omg.domain.game.common.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/Character.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/Character.java
@@ -1,5 +1,0 @@
-package com.chang.omg.domain.game.maplestorym;
-
-public record Character(String ocid) {
-
-}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/CharacterGuild.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/CharacterGuild.java
@@ -1,5 +1,0 @@
-package com.chang.omg.domain.game.maplestorym;
-
-public record CharacterGuild(String guildName) {
-
-}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/domain/GameCharacterSearchLog.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/domain/GameCharacterSearchLog.java
@@ -1,0 +1,42 @@
+package com.chang.omg.domain.game.maplestorym.domain;
+
+import java.util.Objects;
+
+import com.chang.omg.domain.game.common.domain.BaseEntity;
+import com.chang.omg.domain.game.maplestorym.repository.GameTypeConverter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameCharacterSearchLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = GameTypeConverter.class)
+    @Column(name = "game_type", nullable = false)
+    private GameType gameType;
+
+    @Column(name = "world_name")
+    private String worldName;
+
+    @Column(name = "character_name", nullable = false)
+    private String characterName;
+
+    @Builder
+    private GameCharacterSearchLog(final GameType gameType, final String worldName, final String characterName) {
+        this.gameType = Objects.requireNonNull(gameType);
+        this.worldName = Objects.requireNonNull(worldName);
+        this.characterName = Objects.requireNonNull(characterName);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/domain/GameType.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/domain/GameType.java
@@ -1,0 +1,36 @@
+package com.chang.omg.domain.game.maplestorym.domain;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.chang.omg.common.exception.ApiException;
+import com.chang.omg.common.exception.ApiExceptionCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameType {
+    MAPLESTORY_M("메이플스토리M"),
+    CARTRIDER_RUSHPLUS("카트라이더러쉬플러스"),
+    V4("V4"),
+    HIT2("히트2"),
+    KINGDOM_OF_THE_WINDS("바람의나라:연");
+
+    private static final Map<String, GameType> gameTypeMap = Collections.unmodifiableMap(
+            Stream.of(values()).collect(Collectors.toMap(GameType::getName, Function.identity())));
+
+    private final String name;
+
+    public static GameType from(final String value) {
+        if (gameTypeMap.containsKey(value)) {
+            return gameTypeMap.get(value);
+        }
+
+        throw new ApiException(ApiExceptionCode.API_GAME_TYPE_IS_INVALID, value);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/repository/GameCharacterSearchLogRepository.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/repository/GameCharacterSearchLogRepository.java
@@ -1,0 +1,9 @@
+package com.chang.omg.domain.game.maplestorym.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.chang.omg.domain.game.maplestorym.domain.GameCharacterSearchLog;
+
+public interface GameCharacterSearchLogRepository extends JpaRepository<GameCharacterSearchLog, Long> {
+
+}

--- a/src/main/java/com/chang/omg/domain/game/maplestorym/repository/GameTypeConverter.java
+++ b/src/main/java/com/chang/omg/domain/game/maplestorym/repository/GameTypeConverter.java
@@ -1,0 +1,20 @@
+package com.chang.omg.domain.game.maplestorym.repository;
+
+import com.chang.omg.domain.game.maplestorym.domain.GameType;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Convert;
+
+@Convert
+public final class GameTypeConverter implements AttributeConverter<GameType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final GameType gameType) {
+        return gameType.getName();
+    }
+
+    @Override
+    public GameType convertToEntityAttribute(final String gameName) {
+        return GameType.from(gameName);
+    }
+}

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/MapleStoryMApi.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/MapleStoryMApi.java
@@ -1,10 +1,10 @@
 package com.chang.omg.infrastructure.api.maplestorym;
 
-import com.chang.omg.domain.game.maplestorym.Character;
-import com.chang.omg.domain.game.maplestorym.CharacterBasic;
-import com.chang.omg.domain.game.maplestorym.CharacterGuild;
-import com.chang.omg.domain.game.maplestorym.CharacterItemEquipment;
-import com.chang.omg.domain.game.maplestorym.CharacterStat;
+import com.chang.omg.infrastructure.api.maplestorym.dto.Character;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterBasic;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterGuild;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterItemEquipment;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterStat;
 
 public interface MapleStoryMApi {
 

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/MapleStoryMApiRestTemplate.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/MapleStoryMApiRestTemplate.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.chang.omg.domain.game.maplestorym.Character;
-import com.chang.omg.domain.game.maplestorym.CharacterBasic;
-import com.chang.omg.domain.game.maplestorym.CharacterGuild;
-import com.chang.omg.domain.game.maplestorym.CharacterItemEquipment;
-import com.chang.omg.domain.game.maplestorym.CharacterStat;
+import com.chang.omg.infrastructure.api.maplestorym.dto.Character;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterBasic;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterGuild;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterItemEquipment;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterStat;
 import com.chang.omg.infrastructure.config.property.MapleStoryMProperties;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/Character.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/Character.java
@@ -1,0 +1,5 @@
+package com.chang.omg.infrastructure.api.maplestorym.dto;
+
+public record Character(String ocid) {
+
+}

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterBasic.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterBasic.java
@@ -1,4 +1,4 @@
-package com.chang.omg.domain.game.maplestorym;
+package com.chang.omg.infrastructure.api.maplestorym.dto;
 
 public record CharacterBasic(
         String characterName,

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterGuild.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterGuild.java
@@ -1,0 +1,5 @@
+package com.chang.omg.infrastructure.api.maplestorym.dto;
+
+public record CharacterGuild(String guildName) {
+
+}

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterItemEquipment.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterItemEquipment.java
@@ -1,4 +1,4 @@
-package com.chang.omg.domain.game.maplestorym;
+package com.chang.omg.infrastructure.api.maplestorym.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterStat.java
+++ b/src/main/java/com/chang/omg/infrastructure/api/maplestorym/dto/CharacterStat.java
@@ -1,4 +1,4 @@
-package com.chang.omg.domain.game.maplestorym;
+package com.chang.omg.infrastructure.api.maplestorym.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/chang/omg/presentation/game/dto/MapleStoryMCharacterInfoResponse.java
+++ b/src/main/java/com/chang/omg/presentation/game/dto/MapleStoryMCharacterInfoResponse.java
@@ -1,9 +1,9 @@
 package com.chang.omg.presentation.game.dto;
 
-import com.chang.omg.domain.game.maplestorym.CharacterBasic;
-import com.chang.omg.domain.game.maplestorym.CharacterGuild;
-import com.chang.omg.domain.game.maplestorym.CharacterItemEquipment;
-import com.chang.omg.domain.game.maplestorym.CharacterStat;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterBasic;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterGuild;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterItemEquipment;
+import com.chang.omg.infrastructure.api.maplestorym.dto.CharacterStat;
 
 public record MapleStoryMCharacterInfoResponse(
         CharacterBasic characterBasic,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: ${DEV_MYSQL_URL}
+    username: ${DEV_MYSQL_USERNAME}
+    password: ${DEV_MYSQL_PASSWORD}
+
+cors:
+  urls:
+    - ${CLIENT_URL}
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: ${LOCAL_MYSQL_URL}
+    username: ${LOCAL_MYSQL_USERNAME}
+    password: ${LOCAL_MYSQL_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+cors:
+  urls:
+    - http://localhost:3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,13 @@
+spring:
+  profiles:
+    default: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        query.in_clause_parameter_padding: true
 api:
   nexon:
     maplestorym:
@@ -9,7 +19,4 @@ api:
       item_api_uri: ${MAPLESTORYM_ITEM_API_URI}
       stat_api_uri: ${MAPLESTORYM_STAT_API_URI}
       guild_api_uri: ${MAPLESTORYM_GUILD_API_URI}
-cors:
-  urls:
-    - http://localhost:3000
-    - ${CLIENT_URL}
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:omg?serverTimezone=Asia/Seoul
+    username: sa
+    password:
+cors:
+  urls:
+    - http://localhost:3000


### PR DESCRIPTION
## 📄 설명
- 사용자들이 검색하는 게임 캐릭터의 정보를 저장한다.
  - 저장 항목: 게임명, 월드명, 캐릭터명, 검색 시간, 수정 시간

## ✅ 할 일 목록
- [X] dev 환경 MySQL 서버 구축
- [X] 서버 환경 분리 및 MySQL 관련 설정 적용
    - [X] dev, local로 분리
- [X] Jpa 의존성 추가 및 Entity, 서비스 로직 적용
- [X] BaseEntity 추가 및 적용
- [X] GameType Enum 및 Converter 적용

## 💬 기타
- local과 dev 환경은 NAS MySQL 서버 이용
