### PR TITLE
[#24] 게임 검색 로그 저장 에러 수정

### DIFF
--- a/src/main/java/com/chang/omg/application/game/GameService.java
+++ b/src/main/java/com/chang/omg/application/game/GameService.java
@@ -29,8 +29,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GameService {
 
-    private final MapleStoryMApi mapleStoryMApi;
     private final KartRiderApi kartRiderApi;
+    private final MapleStoryMApi mapleStoryMApi;
     private final GameCharacterSearchLogRepository gameCharacterSearchLogRepository;
 
     public MapleStoryMCharacterInfoResponse getMapleStoryMCharacterInfo(
@@ -43,7 +43,7 @@ public class GameService {
         final CharacterStat characterStat = mapleStoryMApi.getCharacterStat(character.ocid());
         final CharacterGuild characterGuild = mapleStoryMApi.getCharacterGuild(character.ocid());
 
-        saveGameCharacterSearchLog(worldName, characterName);
+        saveGameCharacterSearchLog(GameType.MAPLESTORYM, worldName, characterName);
 
         return MapleStoryMCharacterInfoResponse.of(
                 characterBasic,
@@ -59,14 +59,18 @@ public class GameService {
         final UserBasic userBasic = kartRiderApi.getUserBasic(ouid);
         final UserTitleEquipment userTitleEquipment = kartRiderApi.getUserTitleEquipment(ouid);
 
-        saveGameCharacterSearchLog(null, userBasic.racerName());
+        saveGameCharacterSearchLog(GameType.KARTRIDER, null, userBasic.racerName());
 
         return KartRiderUserInfoResponse.of(userBasic, userTitleEquipment);
     }
 
-    private void saveGameCharacterSearchLog(final String worldName, final String characterName) {
+    private void saveGameCharacterSearchLog(
+            final GameType gameType,
+            final String worldName,
+            final String characterName
+    ) {
         final GameCharacterSearchLog gameCharacterSearchLog = GameCharacterSearchLog.builder()
-                .gameType(GameType.MAPLESTORYM)
+                .gameType(gameType)
                 .worldName(worldName)
                 .characterName(characterName)
                 .build();


### PR DESCRIPTION
## 📄 설명
- 게임 검색시 저장되는 로그의 게임 타입을 동적으로 받아서 처리하도록 변경한다.

## ✅ 할 일 목록
- [X] GameService에서 저장 메서드 파라미터 변경

## 💬 기타