### PR TITLE
이벤트와 비동기를 이용한 의존성 분리 및 Retry 전략 추가 - DB 및 Redis 저장 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.retry:spring-retry'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/chang/omg/application/game/dto/RankingDataSave.java
+++ b/src/main/java/com/chang/omg/application/game/dto/RankingDataSave.java
@@ -1,0 +1,8 @@
+package com.chang.omg.application.game.dto;
+
+import com.chang.omg.domains.game.domain.GameType;
+import com.chang.omg.domains.rank.domain.CharacterInfo;
+
+public record RankingDataSave(GameType gameType, CharacterInfo characterInfo) {
+
+}

--- a/src/main/java/com/chang/omg/application/game/handler/GameCharacterSearchLogSaveHandler.java
+++ b/src/main/java/com/chang/omg/application/game/handler/GameCharacterSearchLogSaveHandler.java
@@ -1,0 +1,36 @@
+package com.chang.omg.application.game.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.chang.omg.domains.game.domain.GameCharacterSearchLog;
+import com.chang.omg.domains.game.repository.GameCharacterSearchLogRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameCharacterSearchLogSaveHandler {
+
+    private final GameCharacterSearchLogRepository gameCharacterSearchLogRepository;
+
+    @Async
+    @EventListener
+    @Transactional
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 3000, multiplier = 1.5, maxDelay = 10000),
+            listeners = "retryHandler"
+    )
+    public void saveGameCharacterSearchLog(final GameCharacterSearchLog gameCharacterSearchLog) {
+        gameCharacterSearchLogRepository.save(gameCharacterSearchLog);
+        log.info("game character search log saved : {}", gameCharacterSearchLog.getCharacterName());
+    }
+}

--- a/src/main/java/com/chang/omg/application/game/handler/GameRankingDataSaveHandler.java
+++ b/src/main/java/com/chang/omg/application/game/handler/GameRankingDataSaveHandler.java
@@ -1,0 +1,33 @@
+package com.chang.omg.application.game.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.chang.omg.application.game.dto.RankingDataSave;
+import com.chang.omg.domains.rank.repository.GameRankingRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GameRankingDataSaveHandler {
+
+    private final GameRankingRedisRepository gameRankingRedisRepository;
+
+    @Async
+    @EventListener
+    @Transactional
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 3000, multiplier = 1.5, maxDelay = 10000),
+            listeners = "retryHandler"
+    )
+    public void gameRankingDataSave(final RankingDataSave rankingDataSave) {
+        gameRankingRedisRepository.createOrIncrementScore(rankingDataSave.gameType(), rankingDataSave.characterInfo());
+    }
+}

--- a/src/main/java/com/chang/omg/domains/game/domain/GameCharacterSearchLog.java
+++ b/src/main/java/com/chang/omg/domains/game/domain/GameCharacterSearchLog.java
@@ -13,9 +13,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameCharacterSearchLog extends BaseEntity {
 

--- a/src/main/java/com/chang/omg/global/config/CommonConfig.java
+++ b/src/main/java/com/chang/omg/global/config/CommonConfig.java
@@ -1,0 +1,12 @@
+package com.chang.omg.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@EnableRetry
+@Configuration
+public class CommonConfig {
+
+}

--- a/src/main/java/com/chang/omg/global/config/RetryHandler.java
+++ b/src/main/java/com/chang/omg/global/config/RetryHandler.java
@@ -1,0 +1,37 @@
+package com.chang.omg.global.config;
+
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RetryHandler implements RetryListener {
+
+    @Override
+    public <T, E extends Throwable> boolean open(final RetryContext context, final RetryCallback<T, E> callback) {
+        log.warn("Retry attempt started: {}", context.getRetryCount());
+        return true;
+    }
+
+    @Override
+    public <T, E extends Throwable> void close(final RetryContext context, final RetryCallback<T, E> callback,
+            final Throwable throwable) {
+        log.info("Retry attempt finished: {}", context.getRetryCount());
+    }
+
+    @Override
+    public <T, E extends Throwable> void onSuccess(final RetryContext context, final RetryCallback<T, E> callback,
+            final T result) {
+        log.info("Retry attempt completed: {}", context.getRetryCount());
+    }
+
+    @Override
+    public <T, E extends Throwable> void onError(final RetryContext context, final RetryCallback<T, E> callback,
+            final Throwable throwable) {
+        log.error("Retry attempt failed: {}", context.getRetryCount(), throwable);
+    }
+}


### PR DESCRIPTION
## 📄 설명
- 클라이언트가 게임 캐릭터에 대한 조회시 조회에 대한 로그가 DB에 저장되고, 랭킹과 관련된 데이터가 Redis에 저장되게 됨
- 외부 Nexon 게임 API에서 정상적으로 데이터를 보내오더라도 DB나 Redis를 저장하는 로직에서 예외가 발생되면 같이 묶여서 롤백됨
- 이벤트를 활용하여 DB와 Redis에 저장하는 의존성을 분리하고, 별도의 쓰레드에서 저장되게하여 병렬적으로 처리함

## ✅ 할 일 목록
- [X] EventListener 작성(DB, Redis)
- [X] 이벤트에 대한 예외 처리 구현
  - [X] Spring-Retry 의존성 추가
  - [X] 예외발생시 Retryable을 통한 지속적 요청 구현

## 💬 기타
#### 적용 후 기대효과
- DB나 Redis가 중간에 종료되어도 캐릭터 조회 서비스는 그대로 동작함(DB저장과 Redis 저장을 비동기로 처리)
- DB나 Redis가 종료되어도 Retryable을 통해 5번 재시도함으로써 일반적인 재부팅이나 작은 오류에 대응할 수 있음

#### 고민거리
- 현재는 Retryable을 통해 5번 요청 시도를 하며 시간을 점차 늘려 부하를 줄이는 전략을 선택했지만, 마지막 5번째도 실패하는 경우 실패에 대한 것을 저장하는 테이블이 별도로 없어서 추후 고민해보아야할 상황임
- 현재 Retryable 시간이 점점 늘어나는 것으로 동작시켰는데, 만약 Retryable이 비동기로 동작하는 쓰레드를 그대로 잡고 있다면 DB나 Redis 저장 실패시 사용자의 요청이 많을 수록 대기하는 스레드의 양이 많아져 오류를 범할 수 있음