### PR TITLE
CI/CD 배포 실행 자동화 설정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -8,20 +8,6 @@ jobs:
   deploy-to-ec2:
     environment: dev
     runs-on: ubuntu-latest
-    env:
-      NEXON_BASE_URL: ${{ secrets.NEXON_BASE_URL }}
-      NEXON_HEADER_KEY: ${{ secrets.NEXON_HEADER_KEY }}
-      MAPLESTORYM_HEADER_VALUE: ${{ secrets.MAPLESTORYM_HEADER_VALUE }}
-      MAPLESTORYM_OCID_API_URI: ${{ secrets.MAPLESTORYM_OCID_API_URI }}
-      MAPLESTORYM_BASIC_API_URI: ${{ secrets.MAPLESTORYM_BASIC_API_URI }}
-      MAPLESTORYM_ITEM_API_URI: ${{ secrets.MAPLESTORYM_ITEM_API_URI }}
-      MAPLESTORYM_STAT_API_URI: ${{ secrets.MAPLESTORYM_STAT_API_URI }}
-      MAPLESTORYM_GUILD_API_URI: ${{ secrets.MAPLESTORYM_GUILD_API_URI }}
-      KARTRIDER_HEADER_VALUE: ${{ secrets.KARTRIDER_HEADER_VALUE }}
-      KARTRIDER_OUID_API_URI: ${{ secrets.KARTRIDER_OUID_API_URI }}
-      KARTRIDER_BASIC_API_URI: ${{ secrets.KARTRIDER_BASIC_API_URI }}
-      KARTRIDER_TITLE_API_URI: ${{ secrets.KARTRIDER_TITLE_API_URI }}
-
     steps:
       - name: Github Repository Checkout
         uses: actions/checkout@v3
@@ -46,4 +32,20 @@ jobs:
           password: ${{ secrets.NAS_PASSWORD }}
           source: "build/libs/*.jar"
           target: "/root/omg/"
-            
+
+      - name: Deploy to EC2 and Restart Service
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NAS_HOST }}
+          port: ${{ secrets.NAS_PORT }}
+          username: ${{ secrets.NAS_USERNAME }}
+          password: ${{ secrets.NAS_PASSWORD }}
+          script: |
+            # 기존에 돌아가고 있던 서비스 종료시키기
+            pkill -f 'java.*omg-0.0.1-SNAPSHOT.jar'
+
+            # 새로 배포된 파일 권한 수정
+            chmod 755 ${{ secrets.DIRECTORY_PATH}}/omg-0.0.1-SNAPSHOT.jar
+
+            # 새로운 서비스 실행
+            nohup java -Dspring.profiles.active=dev -jar ${{ secrets.DIRECTORY_PATH}}/omg-0.0.1-SNAPSHOT.jar > ${{ secrets.DIRECTORY_PATH}}/omg-server.log 2>&1 &


### PR DESCRIPTION
## 📄 설명
- 이전에 테스트 후 배포까지만 진행했던 로직을 기존 프로세스를 죽이고 실행하는 로직까지 추가한다.

## ✅ 할 일 목록
- [X] 기존 서버의 환경 변수 수정
- [X] workflows 파일 수정

## 💬 기타
- 외부에서 서버로 SSH 접속시 루트 사용자가 가지고 있는 환경변수를 사용할 수 없는 문제가 발생함
   - ~/.bashrc에 환경변수 모두 export하도록 설정하여 해결