### PR TITLE
[회원] 회원가입 기능, 이메일 인증 기능, 토큰 발행 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.retry:spring-retry'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.1'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.1'
+    
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/chang/omg/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/chang/omg/domain/auth/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.chang.omg.domain.auth.exception;
+
+import com.chang.omg.global.exception.BusinessException;
+import com.chang.omg.global.exception.ExceptionCode;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends BusinessException {
+
+    public AuthException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/com/chang/omg/domain/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,21 @@
+package com.chang.omg.domain.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.chang.omg.global.exception.ExceptionCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthExceptionCode implements ExceptionCode {
+
+    AUTH_EXPIRED_REGISTER_TOKEN(HttpStatus.BAD_REQUEST, "AUT-001", "RegisterToken 토큰 만료"),
+    AUTH_INVALID_TOKEN(HttpStatus.BAD_REQUEST, "AUT-002", "유효하지 않은 Token"),
+    AUTH_FAIL_TO_VALIDATE_TOKEN(HttpStatus.BAD_REQUEST, "AUT-003", "토큰을 검증할 수 없음");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/chang/omg/domain/auth/security/JwtTokenExtractor.java
+++ b/src/main/java/com/chang/omg/domain/auth/security/JwtTokenExtractor.java
@@ -1,0 +1,23 @@
+package com.chang.omg.domain.auth.security;
+
+import org.springframework.stereotype.Component;
+
+import com.chang.omg.domain.auth.exception.AuthException;
+import com.chang.omg.domain.auth.exception.AuthExceptionCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenExtractor {
+
+    private static final String BEARER_TYPE = "Bearer ";
+
+    public String extractToken(final String header) {
+        if (header != null && header.startsWith(BEARER_TYPE)) {
+            return header.substring(BEARER_TYPE.length()).trim();
+        }
+
+        throw new AuthException(AuthExceptionCode.AUTH_INVALID_TOKEN, header);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/auth/security/JwtTokenProvider.java
+++ b/src/main/java/com/chang/omg/domain/auth/security/JwtTokenProvider.java
@@ -1,0 +1,69 @@
+package com.chang.omg.domain.auth.security;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.chang.omg.global.config.property.AuthProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final AuthProperties authProperties;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void initialize() {
+        final byte[] keyBytes = Decoders.BASE64.decode(authProperties.getSecretKey());
+        secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createRegisterToken(final String email) {
+        final Map<String, String> claims = Map.of("email", email);
+
+        return generateToken(TokenType.REGISTER.toString(), claims, authProperties.getRegisterTokenExpirationTime());
+    }
+
+    private String generateToken(final String subject, final Map<String, String> claims, final Long expirationTime) {
+        final Date now = new Date();
+
+        return Jwts.builder()
+                .subject(subject)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getSubject(final String token) {
+        return parseToken(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public String getClaim(final String token, final String claim) {
+        return (String)parseToken(token)
+                .getPayload()
+                .get(claim);
+    }
+
+    private Jws<Claims> parseToken(final String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/auth/security/TokenType.java
+++ b/src/main/java/com/chang/omg/domain/auth/security/TokenType.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.auth.security;
+
+public enum TokenType {
+    REGISTER, LOGIN
+}

--- a/src/main/java/com/chang/omg/domain/game/domain/GameCharacterSearchLog.java
+++ b/src/main/java/com/chang/omg/domain/game/domain/GameCharacterSearchLog.java
@@ -2,8 +2,8 @@ package com.chang.omg.domain.game.domain;
 
 import java.util.Objects;
 
-import com.chang.omg.common.domain.BaseEntity;
 import com.chang.omg.global.converter.GameTypeAttributeConverter;
+import com.chang.omg.global.domain.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;

--- a/src/main/java/com/chang/omg/domain/mail/service/MailMessageTemplate.java
+++ b/src/main/java/com/chang/omg/domain/mail/service/MailMessageTemplate.java
@@ -1,0 +1,20 @@
+package com.chang.omg.domain.mail.service;
+
+import java.text.MessageFormat;
+import java.util.function.Function;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailMessageTemplate {
+    AUTH_CODE(email -> MessageFormat.format("회원가입 인증번호는 {0}입니다.", email)),
+    ;
+
+    private final Function<String, String> messageFormatter;
+
+    public String getMessage(final String value) {
+        return messageFormatter.apply(value);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/mail/service/MailService.java
+++ b/src/main/java/com/chang/omg/domain/mail/service/MailService.java
@@ -1,0 +1,26 @@
+package com.chang.omg.domain.mail.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import com.chang.omg.domain.mail.service.dto.EmailDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendEmail(final EmailDetails emailDetails) {
+        final SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setTo(emailDetails.receiver());
+        message.setSubject(emailDetails.subject());
+        message.setText(emailDetails.message());
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/mail/service/MailSubjectTemplate.java
+++ b/src/main/java/com/chang/omg/domain/mail/service/MailSubjectTemplate.java
@@ -1,0 +1,13 @@
+package com.chang.omg.domain.mail.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailSubjectTemplate {
+    AUTH_CODE("[OhMobileGame] 회원가입 인증번호 입니다."),
+    ;
+
+    private final String subject;
+}

--- a/src/main/java/com/chang/omg/domain/mail/service/dto/EmailDetails.java
+++ b/src/main/java/com/chang/omg/domain/mail/service/dto/EmailDetails.java
@@ -1,0 +1,8 @@
+package com.chang.omg.domain.mail.service.dto;
+
+import lombok.Builder;
+
+@Builder
+public record EmailDetails(String subject, String message, String receiver) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.chang.omg.domain.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.chang.omg.domain.member.controller.dto.MemberCreateRequest;
+import com.chang.omg.domain.member.controller.dto.MemberCreateResponse;
+import com.chang.omg.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<MemberCreateResponse> createMember(
+            @RequestBody @Valid final MemberCreateRequest memberCreateRequest) {
+        final Long memberId = memberService.createMember(memberCreateRequest);
+
+        return ResponseEntity.ok(new MemberCreateResponse(memberId));
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
@@ -6,13 +6,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.chang.omg.domain.auth.security.JwtTokenExtractor;
+import com.chang.omg.domain.auth.security.JwtTokenProvider;
+import com.chang.omg.domain.auth.security.TokenType;
 import com.chang.omg.domain.member.controller.dto.request.MemberAuthCodeRequest;
 import com.chang.omg.domain.member.controller.dto.request.MemberCreateRequest;
 import com.chang.omg.domain.member.controller.dto.request.MemberVerificationRequest;
 import com.chang.omg.domain.member.controller.dto.response.MemberCreateResponse;
-import com.chang.omg.domain.member.controller.dto.response.MemberVeriticationStatusResponse;
+import com.chang.omg.domain.member.controller.dto.response.MemberRegisterTokenResponse;
+import com.chang.omg.domain.member.exception.MemberException;
+import com.chang.omg.domain.member.exception.MemberExceptionCode;
 import com.chang.omg.domain.member.service.MemberService;
 
 import jakarta.validation.Valid;
@@ -23,12 +29,23 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/members")
 public class MemberController {
 
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenExtractor jwtTokenExtractor;
     private final MemberService memberService;
 
     @PostMapping
     public ResponseEntity<MemberCreateResponse> createMember(
-            @RequestBody @Valid final MemberCreateRequest memberCreateRequest
+            @RequestBody @Valid final MemberCreateRequest memberCreateRequest,
+            @RequestHeader final String authorization
     ) {
+        final String registerToken = jwtTokenExtractor.extractToken(authorization);
+        final String tokenType = jwtTokenProvider.getSubject(registerToken);
+        final String tokenEmail = jwtTokenProvider.getClaim(registerToken, "email");
+
+        if (!tokenType.equals(TokenType.REGISTER.toString()) || !tokenEmail.equals(memberCreateRequest.email())) {
+            throw new MemberException(MemberExceptionCode.MEMBER_NOT_MATCHED_TOKEN_DETAILS);
+        }
+
         final Long memberId = memberService.createMember(memberCreateRequest);
 
         return ResponseEntity.ok(new MemberCreateResponse(memberId));
@@ -45,11 +62,11 @@ public class MemberController {
     }
 
     @GetMapping("/verification-auth-code")
-    public ResponseEntity<MemberVeriticationStatusResponse> verifyAuthCode(
-            @ModelAttribute MemberVerificationRequest memberVerificationRequest
+    public ResponseEntity<MemberRegisterTokenResponse> verifyAuthCode(
+            @ModelAttribute final MemberVerificationRequest memberVerificationRequest
     ) {
-        final boolean isVerification = memberService.verifyAuthCode(memberVerificationRequest);
+        final String registerToken = memberService.verifyAuthCode(memberVerificationRequest);
 
-        return ResponseEntity.ok(new MemberVeriticationStatusResponse(isVerification));
+        return ResponseEntity.ok(new MemberRegisterTokenResponse(registerToken));
     }
 }

--- a/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/MemberController.java
@@ -2,12 +2,17 @@ package com.chang.omg.domain.member.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.chang.omg.domain.member.controller.dto.MemberCreateRequest;
-import com.chang.omg.domain.member.controller.dto.MemberCreateResponse;
+import com.chang.omg.domain.member.controller.dto.request.MemberAuthCodeRequest;
+import com.chang.omg.domain.member.controller.dto.request.MemberCreateRequest;
+import com.chang.omg.domain.member.controller.dto.request.MemberVerificationRequest;
+import com.chang.omg.domain.member.controller.dto.response.MemberCreateResponse;
+import com.chang.omg.domain.member.controller.dto.response.MemberVeriticationStatusResponse;
 import com.chang.omg.domain.member.service.MemberService;
 
 import jakarta.validation.Valid;
@@ -22,9 +27,29 @@ public class MemberController {
 
     @PostMapping
     public ResponseEntity<MemberCreateResponse> createMember(
-            @RequestBody @Valid final MemberCreateRequest memberCreateRequest) {
+            @RequestBody @Valid final MemberCreateRequest memberCreateRequest
+    ) {
         final Long memberId = memberService.createMember(memberCreateRequest);
 
         return ResponseEntity.ok(new MemberCreateResponse(memberId));
+    }
+
+    @PostMapping("/verification-auth-code")
+    public ResponseEntity<Void> createAuthCodeAndSendEmail(
+            @RequestBody final MemberAuthCodeRequest memberAuthCodeRequest
+    ) {
+        memberService.createAuthCodeAndSendEmail(memberAuthCodeRequest);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @GetMapping("/verification-auth-code")
+    public ResponseEntity<MemberVeriticationStatusResponse> verifyAuthCode(
+            @ModelAttribute MemberVerificationRequest memberVerificationRequest
+    ) {
+        final boolean isVerification = memberService.verifyAuthCode(memberVerificationRequest);
+
+        return ResponseEntity.ok(new MemberVeriticationStatusResponse(isVerification));
     }
 }

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateRequest.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateRequest.java
@@ -1,0 +1,28 @@
+package com.chang.omg.domain.member.controller.dto;
+
+import java.time.LocalDate;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.chang.omg.domain.member.domain.Member;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberCreateRequest(
+        @Pattern(regexp = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$", message = "이메일 양식 확인 필요") String email,
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,}$", message = "패스워드는 8자 이상이어야 하며, 숫자, 대문자, 소문자, 특수문자를 포함해야 합니다") String password,
+        @NotBlank(message = "닉네임이 없거나 공백인 경우 확인 필요") @Length(min = 3, max = 20, message = "닉네임은 3글자 이상 20글자 이하") String nickname,
+        @NotNull(message = "날짜가 없는 경우 확인 필요") LocalDate birthDate
+) {
+
+    public Member toEntity(final String encryptedPassword) {
+        return Member.builder()
+                .email(email)
+                .password(encryptedPassword)
+                .nickname(nickname)
+                .birthDate(birthDate)
+                .build();
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateResponse.java
@@ -1,5 +1,0 @@
-package com.chang.omg.domain.member.controller.dto;
-
-public record MemberCreateResponse(Long memberId) {
-
-}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/MemberCreateResponse.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto;
+
+public record MemberCreateResponse(Long memberId) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberAuthCodeRequest.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberAuthCodeRequest.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto.request;
+
+public record MemberAuthCodeRequest(String email) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberCreateRequest.java
@@ -1,4 +1,4 @@
-package com.chang.omg.domain.member.controller.dto;
+package com.chang.omg.domain.member.controller.dto.request;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberVerificationRequest.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/request/MemberVerificationRequest.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto.request;
+
+public record MemberVerificationRequest(String email, int authCode) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberCreateResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberCreateResponse.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto.response;
+
+public record MemberCreateResponse(Long memberId) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberRegisterTokenResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberRegisterTokenResponse.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto.response;
+
+public record MemberRegisterTokenResponse(String registerToken) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberVeriticationStatusResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberVeriticationStatusResponse.java
@@ -1,0 +1,5 @@
+package com.chang.omg.domain.member.controller.dto.response;
+
+public record MemberVeriticationStatusResponse(boolean status) {
+
+}

--- a/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberVeriticationStatusResponse.java
+++ b/src/main/java/com/chang/omg/domain/member/controller/dto/response/MemberVeriticationStatusResponse.java
@@ -1,5 +1,0 @@
-package com.chang.omg.domain.member.controller.dto.response;
-
-public record MemberVeriticationStatusResponse(boolean status) {
-
-}

--- a/src/main/java/com/chang/omg/domain/member/domain/Member.java
+++ b/src/main/java/com/chang/omg/domain/member/domain/Member.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 
 import org.springframework.util.StringUtils;
 
-import com.chang.omg.common.domain.BaseEntity;
 import com.chang.omg.domain.member.exception.MemberException;
 import com.chang.omg.domain.member.exception.MemberExceptionCode;
+import com.chang.omg.global.domain.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/chang/omg/domain/member/domain/Member.java
+++ b/src/main/java/com/chang/omg/domain/member/domain/Member.java
@@ -1,0 +1,68 @@
+package com.chang.omg.domain.member.domain;
+
+import java.time.LocalDate;
+
+import org.springframework.util.StringUtils;
+
+import com.chang.omg.common.domain.BaseEntity;
+import com.chang.omg.domain.member.exception.MemberException;
+import com.chang.omg.domain.member.exception.MemberExceptionCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", unique = true, nullable = false, length = 320)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", unique = true, nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    private static final int MAX_EMAIL_LENGTH = 320;
+    private static final int MAX_NICKNAME_LENGTH = 20;
+
+    @Builder
+    public Member(final String email, final String password, final String nickname, final LocalDate birthDate) {
+        this.email = validateEmail(email);
+        this.password = password;
+        this.nickname = validateNickname(nickname);
+        this.birthDate = birthDate;
+    }
+
+    private String validateEmail(final String email) {
+        if (!StringUtils.hasText(email) || email.length() > MAX_EMAIL_LENGTH) {
+            throw new MemberException(MemberExceptionCode.MEMBER_CREATE_FAIL, email);
+        }
+
+        return email;
+    }
+
+    private String validateNickname(final String nickname) {
+        if (!StringUtils.hasText(nickname) || nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new MemberException(MemberExceptionCode.MEMBER_CREATE_FAIL, nickname);
+        }
+
+        return nickname;
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/domain/MemberRedisRepository.java
+++ b/src/main/java/com/chang/omg/domain/member/domain/MemberRedisRepository.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberRedisRepository {
 
     private static final String PREFIX_AUTH_CODE = "AUTH:";
-    private static final int AUTH_CODE_TTL = 120;
+    private static final int AUTH_CODE_TTL = 121;
     private final RedisTemplate<String, Object> redisTemplate;
     private ValueOperations<String, Object> valueOperations;
 

--- a/src/main/java/com/chang/omg/domain/member/domain/MemberRedisRepository.java
+++ b/src/main/java/com/chang/omg/domain/member/domain/MemberRedisRepository.java
@@ -1,0 +1,51 @@
+package com.chang.omg.domain.member.domain;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import com.chang.omg.domain.member.exception.MemberException;
+import com.chang.omg.domain.member.exception.MemberExceptionCode;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MemberRedisRepository {
+
+    private static final String PREFIX_AUTH_CODE = "AUTH:";
+    private static final int AUTH_CODE_TTL = 120;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private ValueOperations<String, Object> valueOperations;
+
+    @PostConstruct
+    public void initialize() {
+        valueOperations = redisTemplate.opsForValue();
+    }
+
+    public void saveAuthCodeWithEmail(final int authCode, final String memberEmail) {
+        valueOperations.set(PREFIX_AUTH_CODE + memberEmail, authCode, AUTH_CODE_TTL, TimeUnit.SECONDS);
+    }
+
+    public boolean existsAuthCodeByEmail(final String memberEmail) {
+        final Object authCode = valueOperations.get(PREFIX_AUTH_CODE + memberEmail);
+
+        return !Objects.isNull(authCode);
+    }
+
+    public int findAuthCodeByEmail(final String memberEmail) {
+        final Object authCode = valueOperations.get(PREFIX_AUTH_CODE + memberEmail);
+
+        if (Objects.isNull(authCode)) {
+            throw new MemberException(MemberExceptionCode.MEMBER_AUTH_CODE_NOT_FOUND, memberEmail);
+        }
+
+        return (int)authCode;
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/domain/MemberRepository.java
+++ b/src/main/java/com/chang/omg/domain/member/domain/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.chang.omg.domain.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/chang/omg/domain/member/exception/MemberException.java
+++ b/src/main/java/com/chang/omg/domain/member/exception/MemberException.java
@@ -1,0 +1,14 @@
+package com.chang.omg.domain.member.exception;
+
+import com.chang.omg.global.exception.BusinessException;
+import com.chang.omg.global.exception.ExceptionCode;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends BusinessException {
+
+    public MemberException(final ExceptionCode exceptionCode, final String rejectedValues) {
+        super(exceptionCode, rejectedValues);
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/exception/MemberException.java
+++ b/src/main/java/com/chang/omg/domain/member/exception/MemberException.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 public class MemberException extends BusinessException {
 
-    public MemberException(final ExceptionCode exceptionCode, final String rejectedValues) {
+    public MemberException(final ExceptionCode exceptionCode, final Object... rejectedValues) {
         super(exceptionCode, rejectedValues);
     }
 }

--- a/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
@@ -16,7 +16,10 @@ public enum MemberExceptionCode implements ExceptionCode {
     MEMBER_CREATE_FAIL(BAD_REQUEST, "MEM-002", "사용자의 입력 값이 잘못되었습니다."),
     MEMBER_ALREADY_EXISTS(BAD_REQUEST, "MEM-003", "가입된 사용자가 이미 존재합니다."),
     MEMBER_ALREADY_GET_AUTH_CODE(BAD_REQUEST, "MEM-004", "사용자가 이미 인증요청을 진행한 상태입니다. 시간이 만료된 이후 다시 요청해주세요."),
-    MEMBER_AUTH_CODE_NOT_FOUND(NOT_FOUND, "MEM-005", "사용자의 인증번호가 만료되었거나 존재하지 않습니다.");
+    MEMBER_AUTH_CODE_NOT_FOUND(NOT_FOUND, "MEM-005", "사용자의 인증번호가 만료되었거나 존재하지 않습니다."),
+    MEMBER_AUTH_CODE_NOT_MATCHED(BAD_REQUEST, "MEM-006", "사용자가 보낸 인증번호가 일치하지 않습니다."),
+    MEMBER_NOT_MATCHED_TOKEN_DETAILS(BAD_REQUEST, "MEM-007", "사용자의 회원가입 정보와 토큰 정보가 일치하지 않습니다."),
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
@@ -1,0 +1,23 @@
+package com.chang.omg.domain.member.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import com.chang.omg.global.exception.ExceptionCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberExceptionCode implements ExceptionCode {
+    MEMBER_NOT_FOUND(NOT_FOUND, "MEM-001", "사용자를 찾을 수 없습니다."),
+    MEMBER_CREATE_FAIL(BAD_REQUEST, "MEM-002", "사용자의 입력 값이 잘못되었습니다."),
+    MEMBER_ALREADY_EXISTS(BAD_REQUEST, "MEM-003", "가입된 사용자가 이미 존재합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/chang/omg/domain/member/exception/MemberExceptionCode.java
@@ -15,7 +15,8 @@ public enum MemberExceptionCode implements ExceptionCode {
     MEMBER_NOT_FOUND(NOT_FOUND, "MEM-001", "사용자를 찾을 수 없습니다."),
     MEMBER_CREATE_FAIL(BAD_REQUEST, "MEM-002", "사용자의 입력 값이 잘못되었습니다."),
     MEMBER_ALREADY_EXISTS(BAD_REQUEST, "MEM-003", "가입된 사용자가 이미 존재합니다."),
-    ;
+    MEMBER_ALREADY_GET_AUTH_CODE(BAD_REQUEST, "MEM-004", "사용자가 이미 인증요청을 진행한 상태입니다. 시간이 만료된 이후 다시 요청해주세요."),
+    MEMBER_AUTH_CODE_NOT_FOUND(NOT_FOUND, "MEM-005", "사용자의 인증번호가 만료되었거나 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/chang/omg/domain/member/service/MemberService.java
+++ b/src/main/java/com/chang/omg/domain/member/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.chang.omg.domain.member.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.chang.omg.domain.member.controller.dto.MemberCreateRequest;
+import com.chang.omg.domain.member.domain.Member;
+import com.chang.omg.domain.member.domain.MemberRepository;
+import com.chang.omg.domain.member.exception.MemberException;
+import com.chang.omg.domain.member.exception.MemberExceptionCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createMember(final MemberCreateRequest memberCreateRequest) {
+        verifyEmailNotRegistered(memberCreateRequest.email());
+
+        final String encryptedPassword = passwordEncoder.encode(memberCreateRequest.password());
+        final Member member = memberCreateRequest.toEntity(encryptedPassword);
+
+        final Member savedMember = memberRepository.save(member);
+
+        return savedMember.getId();
+    }
+
+    private void verifyEmailNotRegistered(final String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberException(MemberExceptionCode.MEMBER_ALREADY_EXISTS, email);
+        }
+    }
+}

--- a/src/main/java/com/chang/omg/domain/member/service/MemberService.java
+++ b/src/main/java/com/chang/omg/domain/member/service/MemberService.java
@@ -4,11 +4,19 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.chang.omg.domain.member.controller.dto.MemberCreateRequest;
+import com.chang.omg.domain.mail.service.MailMessageTemplate;
+import com.chang.omg.domain.mail.service.MailService;
+import com.chang.omg.domain.mail.service.MailSubjectTemplate;
+import com.chang.omg.domain.mail.service.dto.EmailDetails;
+import com.chang.omg.domain.member.controller.dto.request.MemberAuthCodeRequest;
+import com.chang.omg.domain.member.controller.dto.request.MemberCreateRequest;
+import com.chang.omg.domain.member.controller.dto.request.MemberVerificationRequest;
 import com.chang.omg.domain.member.domain.Member;
+import com.chang.omg.domain.member.domain.MemberRedisRepository;
 import com.chang.omg.domain.member.domain.MemberRepository;
 import com.chang.omg.domain.member.exception.MemberException;
 import com.chang.omg.domain.member.exception.MemberExceptionCode;
+import com.chang.omg.global.util.RandomUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,12 +24,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final MailService mailService;
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
+    private final MemberRedisRepository memberRedisRepository;
 
     @Transactional
     public Long createMember(final MemberCreateRequest memberCreateRequest) {
-        verifyEmailNotRegistered(memberCreateRequest.email());
+        verifyEmailAlreadyRegistered(memberCreateRequest.email());
 
         final String encryptedPassword = passwordEncoder.encode(memberCreateRequest.password());
         final Member member = memberCreateRequest.toEntity(encryptedPassword);
@@ -31,9 +41,40 @@ public class MemberService {
         return savedMember.getId();
     }
 
-    private void verifyEmailNotRegistered(final String email) {
+    private void verifyEmailAlreadyRegistered(final String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberException(MemberExceptionCode.MEMBER_ALREADY_EXISTS, email);
         }
+    }
+
+    @Transactional
+    public void createAuthCodeAndSendEmail(final MemberAuthCodeRequest memberAuthCodeRequest) {
+        final String memberEmail = memberAuthCodeRequest.email();
+        verifyAuthCodeAlreadySaved(memberEmail);
+
+        final int authCode = RandomUtils.createAuthCode();
+        memberRedisRepository.saveAuthCodeWithEmail(authCode, memberEmail);
+
+        mailService.sendEmail(
+                new EmailDetails(
+                        MailSubjectTemplate.AUTH_CODE.getSubject(),
+                        MailMessageTemplate.AUTH_CODE.getMessage(String.valueOf(authCode)),
+                        memberEmail
+                )
+        );
+    }
+
+    private void verifyAuthCodeAlreadySaved(final String memberEmail) {
+        final boolean isAuthCodeExists = memberRedisRepository.existsAuthCodeByEmail(memberEmail);
+
+        if (isAuthCodeExists) {
+            throw new MemberException(MemberExceptionCode.MEMBER_ALREADY_GET_AUTH_CODE, memberEmail);
+        }
+    }
+
+    public boolean verifyAuthCode(final MemberVerificationRequest memberVerificationRequest) {
+        final int authCode = memberRedisRepository.findAuthCodeByEmail(memberVerificationRequest.email());
+
+        return authCode == memberVerificationRequest.authCode();
     }
 }

--- a/src/main/java/com/chang/omg/global/config/PropertyConfig.java
+++ b/src/main/java/com/chang/omg/global/config/PropertyConfig.java
@@ -3,6 +3,7 @@ package com.chang.omg.global.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import com.chang.omg.global.config.property.AuthProperties;
 import com.chang.omg.global.config.property.CorsProperties;
 import com.chang.omg.global.config.property.KartRiderProperties;
 import com.chang.omg.global.config.property.MapleStoryMProperties;
@@ -15,7 +16,8 @@ import com.chang.omg.global.config.property.RedisProperties;
         MapleStoryMProperties.class,
         KartRiderProperties.class,
         NexonCommonProperties.class,
-        RedisProperties.class
+        RedisProperties.class,
+        AuthProperties.class
 })
 public class PropertyConfig {
 

--- a/src/main/java/com/chang/omg/global/config/property/AuthProperties.java
+++ b/src/main/java/com/chang/omg/global/config/property/AuthProperties.java
@@ -1,0 +1,17 @@
+package com.chang.omg.global.config.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class AuthProperties {
+
+    private final String secretKey;
+    private final Long accessTokenExpirationTime;
+    private final Long refreshTokenExpirationTime;
+    private final Long registerTokenExpirationTime;
+}

--- a/src/main/java/com/chang/omg/global/domain/BaseEntity.java
+++ b/src/main/java/com/chang/omg/global/domain/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.chang.omg.common.domain;
+package com.chang.omg.global.domain;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/chang/omg/global/exception/GlobalExceptionCode.java
+++ b/src/main/java/com/chang/omg/global/exception/GlobalExceptionCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum GlobalExceptionCode implements ExceptionCode {
 
     GLOBAL_INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLO-001", "서버 내부 에러가 발생하였습니다."),
+    GLOBAL_BAD_REQUEST(BAD_REQUEST, "GLO-002", "사용자의 입력 값이 잘못되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/chang/omg/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chang/omg/global/exception/GlobalExceptionHandler.java
@@ -3,10 +3,15 @@ package com.chang.omg.global.exception;
 import static com.chang.omg.global.exception.GlobalExceptionCode.*;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.chang.omg.domain.member.exception.MemberException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,9 +19,49 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            final MethodArgumentNotValidException e) {
+        final List<FieldError> errors = e.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(FieldError.class::cast)
+                .toList();
+
+        log.warn("사용자 Input 값 예외 발생: {}", GLOBAL_BAD_REQUEST.getMessage(), e);
+
+        errors.forEach(
+                error -> log.warn("{}, field: {}, rejectedValue: {}",
+                        error.getDefaultMessage(),
+                        error.getField(),
+                        error.getRejectedValue()
+                )
+        );
+
+        return ResponseEntity.status(GLOBAL_BAD_REQUEST.getStatus())
+                .body(new ErrorResponse(
+                                GLOBAL_BAD_REQUEST.getCode(),
+                                GLOBAL_BAD_REQUEST.getMessage()
+                        )
+                );
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ErrorResponse> handleMemberException(final MemberException memberException) {
+        log.error("Member 관련 예외 발생: {}", memberException.getMessage(), memberException);
+        log.error(Arrays.toString(memberException.getRejectedValues()));
+
+        return ResponseEntity.status(memberException.getExceptionCode().getStatus())
+                .body(new ErrorResponse(
+                                memberException.getExceptionCode().getCode(),
+                                memberException.getExceptionCode().getMessage()
+                        )
+                );
+    }
+
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleApiException(final ApiException apiException) {
-        log.error("외부 API 요청 에러: {}", apiException.getMessage(), apiException);
+        log.error("외부 API 요청 예외 발생: {}", apiException.getMessage(), apiException);
         log.error(Arrays.toString(apiException.getRejectedValues()));
 
         return ResponseEntity.status(apiException.getExceptionCode().getStatus())

--- a/src/main/java/com/chang/omg/global/security/SecurityConfig.java
+++ b/src/main/java/com/chang/omg/global/security/SecurityConfig.java
@@ -38,7 +38,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth ->
                         auth.requestMatchers("/games/**", "/rank/**").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/members").permitAll()
-                                .anyRequest().authenticated()
+                                .requestMatchers("/members/verification-auth-code").permitAll()
+                                .anyRequest()
+                                .authenticated()
                 );
 
         return httpSecurity.build();

--- a/src/main/java/com/chang/omg/global/security/SecurityConfig.java
+++ b/src/main/java/com/chang/omg/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,8 +36,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/games/**").permitAll()
-                                .requestMatchers("/rank/**").permitAll()
+                        auth.requestMatchers("/games/**", "/rank/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/members").permitAll()
                                 .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/chang/omg/global/util/RandomUtils.java
+++ b/src/main/java/com/chang/omg/global/util/RandomUtils.java
@@ -1,0 +1,14 @@
+package com.chang.omg.global.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RandomUtils {
+
+    public static int createAuthCode() {
+        return ThreadLocalRandom.current().nextInt(1000, 10000);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,17 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         query.in_clause_parameter_padding: true
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PASSWORD}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 api:
   nexon:
     common:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         query.in_clause_parameter_padding: true
   mail:
     host: ${MAIL_HOST}
-    port: ${MAIL_PASSWORD}
+    port: ${MAIL_PORT}
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
     properties:
@@ -37,3 +37,8 @@ api:
       basic_api_uri: ${KARTRIDER_BASIC_API_URI}
       title_api_uri: ${KARTRIDER_TITLE_API_URI}
 
+jwt:
+  secret-key: ${SECRET_KEY}
+  access-token-expiration-time: ${ACCESS_TOKEN_EXPIRATION_TIME}
+  refresh-token-expiration-time: ${REFRESH_TOKEN_EXPIRATION_TIME}
+  register-token-expiration-time: ${REGISTER_TOKEN_EXPIRATION_TIME}


### PR DESCRIPTION
## 📄 설명
- 회원 도메인의 회원가입 기능 구현한다.
- 회원가입시 이메일을 통해 인증할 수 있도록 구현한다.
- 이메일 인증 성공시 인증된 사용자만 회원가입할 수 있도록 별도의 회원가입 토큰을 발행한다.

## ✅ 할 일 목록
- [X] 회원 테이블 생성
- [X] 회원가입 기능(암호화 처리)
- [X] 이메일 인증 기능 구현
   - [X] Redis에 인증 번호 저장
- [X] 이메일 인증 성공시 인증된 사용자임을 구분하는 회원가입 토큰 발행

## 💬 기타
- 메일 템플릿화 및 추상화 -> 추후 메시지로 바뀔 수도 있지 않을까?
- 토큰 발급과 검증에 대한 로직은 로그인 구현 후 조금 더 디테일하게 변경하고 재사용을 위해 코드 리팩토링 필요
- 회원가입과 관련된 테스트 코드 작성 필요